### PR TITLE
Support NewExpression - instances without parameters

### DIFF
--- a/src/NeinLinq/SelectorTranslator.cs
+++ b/src/NeinLinq/SelectorTranslator.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 
@@ -42,15 +43,18 @@ namespace NeinLinq
             var leftNew = left.Body as NewExpression ?? leftInit?.NewExpression;
             var rightNew = right.Body as NewExpression ?? rightInit?.NewExpression;
 
-            var bindings = Enumerable.Empty<MemberBinding>();
+            var bindings = new List<MemberBinding>();
 
             if (leftNew != null && rightNew != null)
             {
                 if (leftNew.Arguments.Any() || rightNew.Arguments.Any())
                     throw new NotSupportedException("Only parameterless constructors are supported yet.");
 
-                if (leftInit != null && rightInit != null)
-                    bindings = leftInit.Bindings.Concat(rightInit.Bindings);
+                if (leftInit != null)
+                    bindings.AddRange(leftInit.Bindings);
+
+                if (rightInit != null)
+                    bindings.AddRange(rightInit.Bindings);
             }
             else
                 throw new NotSupportedException("Only member init expressions and new expressions are supported yet.");

--- a/src/NeinLinq/SelectorTranslator.cs
+++ b/src/NeinLinq/SelectorTranslator.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 
@@ -43,21 +42,13 @@ namespace NeinLinq
             var leftNew = left.Body as NewExpression ?? leftInit?.NewExpression;
             var rightNew = right.Body as NewExpression ?? rightInit?.NewExpression;
 
-            var bindings = new List<MemberBinding>();
-
-            if (leftNew != null && rightNew != null)
-            {
-                if (leftNew.Arguments.Any() || rightNew.Arguments.Any())
-                    throw new NotSupportedException("Only parameterless constructors are supported yet.");
-
-                if (leftInit != null)
-                    bindings.AddRange(leftInit.Bindings);
-
-                if (rightInit != null)
-                    bindings.AddRange(rightInit.Bindings);
-            }
-            else
+            if (leftNew == null || rightNew == null)
                 throw new NotSupportedException("Only member init expressions and new expressions are supported yet.");
+            if (leftNew.Arguments.Any() || rightNew.Arguments.Any())
+                throw new NotSupportedException("Only parameterless constructors are supported yet.");
+
+            var leftBindings = leftInit?.Bindings ?? Enumerable.Empty<MemberBinding>();
+            var rightBindings = rightInit?.Bindings ?? Enumerable.Empty<MemberBinding>();
 
             var l = left.Parameters[0];
             var r = right.Parameters[0];
@@ -65,7 +56,7 @@ namespace NeinLinq
             var binder = new ParameterBinder(l, r);
 
             return Expression.Lambda<Func<TSource, TResult>>(
-                binder.Visit(Expression.MemberInit(Expression.New(typeof(TResult)), bindings)), r);
+                binder.Visit(Expression.MemberInit(Expression.New(typeof(TResult)), leftBindings.Concat(rightBindings))), r);
         }
     }
 }

--- a/test/NeinLinq.Tests/SelectorTranslator/ApplyTest.cs
+++ b/test/NeinLinq.Tests/SelectorTranslator/ApplyTest.cs
@@ -53,6 +53,51 @@ namespace NeinLinq.Tests.SelectorTranslator
 
             var select = s.Apply(t);
             var result = data.OfType<Dummy>().Except(data.OfType<SuperDummy>()).Select(select);
+
+            Assert.Collection(result,
+                v => { Assert.Equal(0, v.Id); Assert.Null(v.Name); },
+                v => { Assert.Equal(0, v.Id); Assert.Null(v.Name); },
+                v => { Assert.Equal(0, v.Id); Assert.Null(v.Name); });
+        }
+
+        [Fact]
+        public void ShouldNotLoseBindingsOnMixedExpressions()
+        {
+            Expression<Func<Dummy, DummyView>> s = d => new DummyView();
+            Expression<Func<Dummy, DummyView>> t = d => new DummyView
+            {
+                Id = d.Id + 5,
+                Name = d.Name
+            };
+
+            var select = s.Apply(t);
+            var result = data.OfType<Dummy>().Except(data.OfType<SuperDummy>()).Select(select);
+
+            Assert.Collection(result,
+                v => { Assert.Equal(6, v.Id); Assert.Equal("Asdf", v.Name); },
+                v => { Assert.Equal(7, v.Id); Assert.Equal("Narf", v.Name); },
+                v => { Assert.Equal(8, v.Id); Assert.Equal("Qwer", v.Name); }
+            );
+        }
+
+        [Fact]
+        public void ShouldNotLoseBindingsOnMixedExpressionsReversed()
+        {
+            Expression<Func<Dummy, DummyView>> s = d => new DummyView();
+            Expression<Func<Dummy, DummyView>> t = d => new DummyView
+            {
+                Id = d.Id + 5,
+                Name = d.Name
+            };
+
+            var select = t.Apply(s);
+            var result = data.OfType<Dummy>().Except(data.OfType<SuperDummy>()).Select(select);
+
+            Assert.Collection(result,
+                v => { Assert.Equal(6, v.Id); Assert.Equal("Asdf", v.Name); },
+                v => { Assert.Equal(7, v.Id); Assert.Equal("Narf", v.Name); },
+                v => { Assert.Equal(8, v.Id); Assert.Equal("Qwer", v.Name); }
+            );
         }
     }
 }

--- a/test/NeinLinq.Tests/SelectorTranslator/ApplyTest.cs
+++ b/test/NeinLinq.Tests/SelectorTranslator/ApplyTest.cs
@@ -44,5 +44,15 @@ namespace NeinLinq.Tests.SelectorTranslator
                 v => { Assert.Equal(2, v.Id); Assert.Equal("Narf", v.Name); },
                 v => { Assert.Equal(3, v.Id); Assert.Equal("Qwer", v.Name); });
         }
+
+        [Fact]
+        public void ShouldNotThrowOnEmptyNewExpression()
+        {
+            Expression<Func<Dummy, DummyView>> s = d => new DummyView();
+            Expression<Func<Dummy, DummyView>> t = d => new DummyView();
+
+            var select = s.Apply(t);
+            var result = data.OfType<Dummy>().Except(data.OfType<SuperDummy>()).Select(select);
+        }
     }
 }


### PR DESCRIPTION
This PR fixes an issue in the SelectorTranslator with NewExpression - instances without parameters. This is a problem, since
`new FooView{<no binding>}` is treated as MemberInitExpression, while
`new FooView(<no parameters>)` is treated as NewExpression and will therefore lead to an exception - those calls are equivalent, though.

Many refactoring tools would recommend changing `new FooView{}` to `new FooView()`, which could potentially cause problems at runtime.