### PR TITLE
Support external property-getters as injection-source

### DIFF
--- a/src/NeinLinq/InjectLambdaMetadata.cs
+++ b/src/NeinLinq/InjectLambdaMetadata.cs
@@ -63,8 +63,11 @@ namespace NeinLinq
             var args = new[] { property.DeclaringType };
             var result = property.PropertyType;
 
+            // apply "Expr" convention for property "overloading"
+            var method = metadata?.Target == null ? property.Name + "Expr" : property.Name;
+
             // special treatment for super-heroic property getters
-            return FixedLambdaFactory(metadata, property.DeclaringType, property.Name, args, result, false);
+            return FixedLambdaFactory(metadata, property.DeclaringType, method, args, result, false);
         }
 
         static Func<Expression, LambdaExpression> FixedLambdaFactory(InjectLambdaAttribute metadata, Type target, string method, Type[] args, Type result, bool instance)
@@ -129,12 +132,8 @@ namespace NeinLinq
         {
             // assume method without any parameters
             var factory = target.GetRuntimeMethod(method, emptyTypes)
-                          ?? target.GetRuntimeProperty(method + "Expr")?.GetMethod
-                          
-                          //try resolving a property getter from type different to injection-target
-                          ?? (target != args[0] 
-                            ? target.GetRuntimeProperty(method)?.GetMethod 
-                            : null);
+                ?? target.GetRuntimeProperty(method)?.GetMethod;
+            
 
             if (factory == null)
                 throw new InvalidOperationException($"Unable to retrieve lambda expression from {target.FullName}.{method}: no parameterless member found.");

--- a/src/NeinLinq/InjectLambdaMetadata.cs
+++ b/src/NeinLinq/InjectLambdaMetadata.cs
@@ -128,7 +128,14 @@ namespace NeinLinq
         static MethodInfo FactoryMethod(Type target, string method, Type[] args, Type result, bool instance)
         {
             // assume method without any parameters
-            var factory = target.GetRuntimeMethod(method, emptyTypes) ?? target.GetRuntimeProperty(method + "Expr")?.GetMethod;
+            var factory = target.GetRuntimeMethod(method, emptyTypes)
+                          ?? target.GetRuntimeProperty(method + "Expr")?.GetMethod
+                          
+                          //try resolving a property getter from type different to injection-target
+                          ?? (target != args[0] 
+                            ? target.GetRuntimeProperty(method)?.GetMethod 
+                            : null);
+
             if (factory == null)
                 throw new InvalidOperationException($"Unable to retrieve lambda expression from {target.FullName}.{method}: no parameterless member found.");
 

--- a/test/NeinLinq.Fakes/InjectableQuery/Dummy.cs
+++ b/test/NeinLinq.Fakes/InjectableQuery/Dummy.cs
@@ -38,6 +38,9 @@ namespace NeinLinq.Fakes.InjectableQuery
             get { throw new NotSupportedException(); }
         }
 
+        [InjectLambda(typeof(DummyExtensions), nameof(DummyExtensions.VelocityExternalPropertyGetter))]
+        public double VelocityExternalPropertyGetter { get; }
+
         public double VelocityWithConvention { get; }
 
         public static Expression<Func<Dummy, double>> VelocityWithConventionExpr => v => v.Distance / v.Time;

--- a/test/NeinLinq.Fakes/InjectableQuery/DummyExtensions.cs
+++ b/test/NeinLinq.Fakes/InjectableQuery/DummyExtensions.cs
@@ -9,5 +9,7 @@ namespace NeinLinq.Fakes.InjectableQuery
         {
             return v => v.Distance / v.Time;
         }
+
+        public static Expression<Func<Dummy, double>> VelocityExternalPropertyGetter => v => v.Distance / v.Time;
     }
 }

--- a/test/NeinLinq.Tests/InjectableQuery/QueryPropertyTest.cs
+++ b/test/NeinLinq.Tests/InjectableQuery/QueryPropertyTest.cs
@@ -110,6 +110,17 @@ namespace NeinLinq.Tests.InjectableQuery
         }
 
         [Fact]
+        public void ShouldSucceedWithExternalPropertyGetterWithGetter()
+        {
+            var query = from d in data.ToInjectable()
+                        select d.VelocityExternalPropertyGetter;
+
+            var result = query.ToList();
+
+            Assert.Equal(new[] { 200.0, .0, .125 }, result);
+        }
+
+        [Fact]
         public void ShouldFailWithInvalidSiblingResult()
         {
             var query = from d in data.ToInjectable(typeof(Dummy))

--- a/test/NeinLinq.Tests/InjectableQuery/QueryPropertyTest.cs
+++ b/test/NeinLinq.Tests/InjectableQuery/QueryPropertyTest.cs
@@ -40,7 +40,7 @@ namespace NeinLinq.Tests.InjectableQuery
 
             var error = Assert.Throws<InvalidOperationException>(() => query.ToList());
 
-            Assert.Equal("Unable to retrieve lambda expression from NeinLinq.Fakes.InjectableQuery.Dummy.VelocityWithoutSibling: no parameterless member found.", error.Message);
+            Assert.Equal("Unable to retrieve lambda expression from NeinLinq.Fakes.InjectableQuery.Dummy.VelocityWithoutSiblingExpr: no parameterless member found.", error.Message);
         }
 
         [Fact]
@@ -128,7 +128,7 @@ namespace NeinLinq.Tests.InjectableQuery
 
             var error = Assert.Throws<InvalidOperationException>(() => query.ToList());
 
-            Assert.Equal("Unable to retrieve lambda expression from NeinLinq.Fakes.InjectableQuery.Dummy.VelocityWithInvalidSiblingResult: method returns no lambda expression.", error.Message);
+            Assert.Equal("Unable to retrieve lambda expression from NeinLinq.Fakes.InjectableQuery.Dummy.VelocityWithInvalidSiblingResultExpr: method returns no lambda expression.", error.Message);
         }
 
         [Fact]
@@ -139,7 +139,7 @@ namespace NeinLinq.Tests.InjectableQuery
 
             var error = Assert.Throws<InvalidOperationException>(() => query.ToList());
 
-            Assert.Equal("Unable to retrieve lambda expression from NeinLinq.Fakes.InjectableQuery.Dummy.VelocityWithInvalidSiblingSignature: method returns non-matching expression.", error.Message);
+            Assert.Equal("Unable to retrieve lambda expression from NeinLinq.Fakes.InjectableQuery.Dummy.VelocityWithInvalidSiblingSignatureExpr: method returns non-matching expression.", error.Message);
         }
     }
 }


### PR DESCRIPTION
NeinLinq doesn't support constructs like

```cs
public class MyModel {

    [InjectLambda(typeof(MyModelExtensions), nameof(MyModelExpression.Narf)]
    public bool Narf { get { throw new Exception(); } }
}

public static class MyModelExpressions {
    public Expression<Func<Narf,bool>> Narf => n => true;
}
```

NeinLinq only supports property-getters when they are named after the injection-target with the suffix "Expr" - in this case "NarfExpr".