### PR TITLE
Add EF extension for lambda injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,13 @@ Usage of specific flavors is encouraged for EF6 / EFCore (otherwise async querie
 
     PM> Install-Package NeinLinq.Interactive
 
+***New:***  with Version `5.1.0` the package *NeinLinq.EntityFrameworkCore* introduced an explicit `DbContext` extension for enabling *Lambda injection* globally:
+
+```csharp
+    services.AddDbContext<MyContext>(options =>
+         options.UseSqlOrTheLike("...").WithLambdaInjection());
+```
+
 Lambda injection
 ----------------
 

--- a/build.props
+++ b/build.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Nullable>Enable</Nullable>
     <LangVersion>9.0</LangVersion>
-    <VersionPrefix>5.0.1</VersionPrefix>
+    <VersionPrefix>5.1.0</VersionPrefix>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    patch:
+      default:
+        target: 80%
+    project:
+      default:
+        target: 90%

--- a/pack.props
+++ b/pack.props
@@ -31,7 +31,7 @@ To support different LINQ implementations, the following flavours are available.
     <PackageIcon>icon.png</PackageIcon>
     <PackageProjectUrl>https://github.com/axelheer/nein-linq</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageReleaseNotes>Improved handling of dynamic lambda factories.</PackageReleaseNotes>
+    <PackageReleaseNotes>Add EF Core extension for global lambda injection.</PackageReleaseNotes>
     <PackageTags>LINQ;EF;IX</PackageTags>
   </PropertyGroup>
 

--- a/src/NeinLinq.EntityFrameworkCore/InjectableDbContextOptionsBuilderExtensions.cs
+++ b/src/NeinLinq.EntityFrameworkCore/InjectableDbContextOptionsBuilderExtensions.cs
@@ -1,0 +1,37 @@
+using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+
+#pragma warning disable CA1508
+
+namespace NeinLinq
+{
+    /// <summary>
+    /// Replaces method calls with lambda expressions.
+    /// </summary>
+    public static class InjectableDbContextOptionsBuilderExtensions
+    {
+        /// <summary>
+        /// Replaces method calls with lambda expressions.
+        /// </summary>
+        /// <param name="optionsBuilder">The builder being used to configure the context.</param>
+        /// <param name="greenlist">A list of types to inject, whether marked as injectable or not.</param>
+        /// <returns>The options builder so that further configuration can be chained.</returns>
+        public static DbContextOptionsBuilder WithLambdaInjection(this DbContextOptionsBuilder optionsBuilder, params Type[] greenlist)
+        {
+            if (optionsBuilder is null)
+                throw new ArgumentNullException(nameof(optionsBuilder));
+            if (greenlist is null)
+                throw new ArgumentNullException(nameof(greenlist));
+
+            var extension = GetOrCreateExtension(optionsBuilder).WithParams(greenlist);
+            ((IDbContextOptionsBuilderInfrastructure)optionsBuilder).AddOrUpdateExtension(extension);
+
+            return optionsBuilder;
+        }
+
+        private static InjectableDbContextOptionsExtension GetOrCreateExtension(DbContextOptionsBuilder optionsBuilder)
+            => optionsBuilder.Options.FindExtension<InjectableDbContextOptionsExtension>()
+                ?? new InjectableDbContextOptionsExtension();
+    }
+}

--- a/src/NeinLinq.EntityFrameworkCore/InjectableDbContextOptionsExtension.cs
+++ b/src/NeinLinq.EntityFrameworkCore/InjectableDbContextOptionsExtension.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.Extensions.DependencyInjection;
+
+#pragma warning disable CA1307
+#pragma warning disable CA1508
+#pragma warning disable CA1822
+
+namespace NeinLinq
+{
+    internal class InjectableDbContextOptionsExtension : IDbContextOptionsExtension
+    {
+        private readonly Type[] greenlist;
+
+        public InjectableDbContextOptionsExtension(params Type[] greenlist)
+        {
+            this.greenlist = greenlist ?? throw new ArgumentNullException(nameof(greenlist));
+        }
+
+        public DbContextOptionsExtensionInfo Info
+            => new ExtensionInfo(this);
+
+        public void ApplyServices(IServiceCollection services)
+        {
+            if (services is null)
+                throw new ArgumentNullException(nameof(services));
+
+            for (var index = services.Count - 1; index >= 0; index--)
+            {
+                var descriptor = services[index];
+                if (descriptor.ServiceType != typeof(IQueryTranslationPreprocessorFactory))
+                    continue;
+                if (descriptor.ImplementationType is null)
+                    continue;
+
+                // Add Injectable factory for actual implementation
+                services[index] = new ServiceDescriptor(
+                    descriptor.ServiceType,
+                    typeof(InjectableQueryTranslationPreprocessorFactory<>)
+                        .MakeGenericType(descriptor.ImplementationType),
+                    descriptor.Lifetime
+                );
+
+                // Add actual implementation as it is
+                services.Add(
+                    new ServiceDescriptor(
+                        descriptor.ImplementationType,
+                        descriptor.ImplementationType,
+                        descriptor.Lifetime
+                    )
+                );
+            }
+
+            _ = services.AddSingleton(new InjectableQueryTranslationPreprocessorOptions(greenlist));
+        }
+
+        public InjectableDbContextOptionsExtension WithParams(Type[] greenlist)
+        {
+            if (greenlist is null)
+                throw new ArgumentNullException(nameof(greenlist));
+
+            return new InjectableDbContextOptionsExtension(greenlist);
+        }
+
+        public void Validate(IDbContextOptions options)
+        {
+        }
+
+        private class ExtensionInfo : DbContextOptionsExtensionInfo
+        {
+            public ExtensionInfo(IDbContextOptionsExtension extension)
+                : base(extension)
+            {
+            }
+
+            public override bool IsDatabaseProvider
+                => false;
+
+            public override string LogFragment
+                => "LambdaInjection";
+
+            public override long GetServiceProviderHashCode()
+                => "LambdaInjection".GetHashCode();
+
+            public override void PopulateDebugInfo(IDictionary<string, string> debugInfo)
+            {
+            }
+        }
+    }
+}

--- a/src/NeinLinq.EntityFrameworkCore/InjectableQueryTranslationPreprocessor.cs
+++ b/src/NeinLinq.EntityFrameworkCore/InjectableQueryTranslationPreprocessor.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore.Query;
 
@@ -6,6 +7,7 @@ using Microsoft.EntityFrameworkCore.Query;
 
 namespace NeinLinq
 {
+    [ExcludeFromCodeCoverage]
     internal class InjectableQueryTranslationPreprocessor : QueryTranslationPreprocessor
     {
         private readonly InjectableQueryTranslationPreprocessorOptions options;

--- a/src/NeinLinq.EntityFrameworkCore/InjectableQueryTranslationPreprocessor.cs
+++ b/src/NeinLinq.EntityFrameworkCore/InjectableQueryTranslationPreprocessor.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Query;
+
+#pragma warning disable CA1812
+
+namespace NeinLinq
+{
+    internal class InjectableQueryTranslationPreprocessor : QueryTranslationPreprocessor
+    {
+        private readonly InjectableQueryTranslationPreprocessorOptions options;
+        private readonly QueryTranslationPreprocessor innerPreprocessor;
+
+        public InjectableQueryTranslationPreprocessor(InjectableQueryTranslationPreprocessorOptions options,
+                                                      QueryTranslationPreprocessorDependencies dependencies,
+                                                      QueryCompilationContext queryCompilationContext,
+                                                      QueryTranslationPreprocessor innerPreprocessor)
+            : base(dependencies, queryCompilationContext)
+        {
+            this.options = options ?? throw new ArgumentNullException(nameof(options));
+            this.innerPreprocessor = innerPreprocessor ?? throw new ArgumentNullException(nameof(innerPreprocessor));
+        }
+
+        public override Expression Process(Expression query)
+        {
+            var rewriter = new InjectableQueryRewriter(options.Greenlist);
+
+            return innerPreprocessor.Process(rewriter.Visit(query));
+        }
+    }
+}

--- a/src/NeinLinq.EntityFrameworkCore/InjectableQueryTranslationPreprocessorFactory.cs
+++ b/src/NeinLinq.EntityFrameworkCore/InjectableQueryTranslationPreprocessorFactory.cs
@@ -1,10 +1,12 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.EntityFrameworkCore.Query;
 
 #pragma warning disable CA1812
 
 namespace NeinLinq
 {
+    [ExcludeFromCodeCoverage]
     internal class InjectableQueryTranslationPreprocessorFactory<TInnerFactory> : IQueryTranslationPreprocessorFactory
         where TInnerFactory : class, IQueryTranslationPreprocessorFactory
     {

--- a/src/NeinLinq.EntityFrameworkCore/InjectableQueryTranslationPreprocessorFactory.cs
+++ b/src/NeinLinq.EntityFrameworkCore/InjectableQueryTranslationPreprocessorFactory.cs
@@ -1,0 +1,27 @@
+using System;
+using Microsoft.EntityFrameworkCore.Query;
+
+#pragma warning disable CA1812
+
+namespace NeinLinq
+{
+    internal class InjectableQueryTranslationPreprocessorFactory<TInnerFactory> : IQueryTranslationPreprocessorFactory
+        where TInnerFactory : class, IQueryTranslationPreprocessorFactory
+    {
+        private readonly InjectableQueryTranslationPreprocessorOptions options;
+        private readonly QueryTranslationPreprocessorDependencies dependencies;
+        private readonly TInnerFactory innerFactory;
+
+        public InjectableQueryTranslationPreprocessorFactory(InjectableQueryTranslationPreprocessorOptions options,
+                                                             QueryTranslationPreprocessorDependencies dependencies,
+                                                             TInnerFactory innerFactory)
+        {
+            this.options = options ?? throw new ArgumentNullException(nameof(options));
+            this.dependencies = dependencies ?? throw new ArgumentNullException(nameof(dependencies));
+            this.innerFactory = innerFactory ?? throw new ArgumentNullException(nameof(innerFactory));
+        }
+
+        public QueryTranslationPreprocessor Create(QueryCompilationContext queryCompilationContext)
+            => new InjectableQueryTranslationPreprocessor(options, dependencies, queryCompilationContext, innerFactory.Create(queryCompilationContext));
+    }
+}

--- a/src/NeinLinq.EntityFrameworkCore/InjectableQueryTranslationPreprocessorOptions.cs
+++ b/src/NeinLinq.EntityFrameworkCore/InjectableQueryTranslationPreprocessorOptions.cs
@@ -1,7 +1,9 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace NeinLinq
 {
+    [ExcludeFromCodeCoverage]
     internal class InjectableQueryTranslationPreprocessorOptions
     {
         public Type[] Greenlist { get; }

--- a/src/NeinLinq.EntityFrameworkCore/InjectableQueryTranslationPreprocessorOptions.cs
+++ b/src/NeinLinq.EntityFrameworkCore/InjectableQueryTranslationPreprocessorOptions.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace NeinLinq
+{
+    internal class InjectableQueryTranslationPreprocessorOptions
+    {
+        public Type[] Greenlist { get; }
+
+        public InjectableQueryTranslationPreprocessorOptions(Type[] greenlist)
+        {
+            Greenlist = greenlist ?? throw new ArgumentNullException(nameof(greenlist));
+        }
+    }
+}

--- a/test/NeinLinq.Fakes/EntityExtension/Dummy.cs
+++ b/test/NeinLinq.Fakes/EntityExtension/Dummy.cs
@@ -1,0 +1,9 @@
+namespace NeinLinq.Fakes.EntityExtension
+{
+    public class Dummy
+    {
+        public int Id { get; set; }
+
+        public string? Name { get; set; }
+    }
+}

--- a/test/NeinLinq.Fakes/EntityExtension/DummyExtensions.cs
+++ b/test/NeinLinq.Fakes/EntityExtension/DummyExtensions.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Linq.Expressions;
+
+#pragma warning disable CA1801
+#pragma warning disable CA1822
+
+namespace NeinLinq.Fakes.EntityExtension
+{
+    public static class DummyExtensions
+    {
+        [InjectLambda]
+        public static bool IsNarf(this Dummy dummy)
+            => throw new InvalidOperationException();
+
+        public static Expression<Func<Dummy, bool>> IsNarf()
+            => d => d.Name == "Narf";
+    }
+}

--- a/test/NeinLinq.Tests/EntityExtension/Context.cs
+++ b/test/NeinLinq.Tests/EntityExtension/Context.cs
@@ -1,0 +1,16 @@
+using Microsoft.EntityFrameworkCore;
+using NeinLinq.Fakes.EntityExtension;
+
+namespace NeinLinq.Tests.EntityExtension
+{
+    public class Context : DbContext
+    {
+        public DbSet<Dummy> Dummies { get; }
+
+        public Context(DbContextOptions<Context> options)
+            : base(options)
+        {
+            Dummies = Set<Dummy>();
+        }
+    }
+}

--- a/test/NeinLinq.Tests/EntityExtension/ExtensionTest.cs
+++ b/test/NeinLinq.Tests/EntityExtension/ExtensionTest.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using NeinLinq.Fakes.EntityExtension;
+using Xunit;
+
+namespace NeinLinq.Tests.EntityExtension
+{
+    public class ExtensionTest
+    {
+        [Fact]
+        public void ShouldInject()
+        {
+            var services = new ServiceCollection();
+
+            _ = services.AddDbContext<Context>(options =>
+                options.UseSqlite("Data Source=NeinLinq.EntityExtension.db").WithLambdaInjection());
+
+            using var serviceProvider = services.BuildServiceProvider();
+
+            var context = serviceProvider.GetRequiredService<Context>();
+
+            _ = context.Database.EnsureDeleted();
+            _ = context.Database.EnsureCreated();
+
+            context.Dummies.AddRange(
+                new Dummy { Name = "Heinz" },
+                new Dummy { Name = "Narf" },
+                new Dummy { Name = "Wat" }
+            );
+
+            _ = context.SaveChanges();
+
+            var query = from d in context.Dummies.AsQueryable()
+                        where d.IsNarf()
+                        select d.Id;
+
+            Assert.Equal(1, query.Count());
+        }
+
+        [Fact]
+        public void ShouldNotInject()
+        {
+            var services = new ServiceCollection();
+
+            _ = services.AddDbContext<Context>(options =>
+                options.UseSqlite("Data Source=NeinLinq.EntityExtension.db"));
+
+            using var serviceProvider = services.BuildServiceProvider();
+
+            var context = serviceProvider.GetRequiredService<Context>();
+
+            _ = context.Database.EnsureDeleted();
+            _ = context.Database.EnsureCreated();
+
+            var query = from d in context.Dummies.AsQueryable()
+                        where d.IsNarf()
+                        select d.Id;
+
+            _ = Assert.Throws<InvalidOperationException>(() => query.Count());
+        }
+    }
+}

--- a/test/NeinLinq.Tests/EntityExtension/ExtensionTest.cs
+++ b/test/NeinLinq.Tests/EntityExtension/ExtensionTest.cs
@@ -10,6 +10,13 @@ namespace NeinLinq.Tests.EntityExtension
     public class ExtensionTest
     {
         [Fact]
+        public void ShouldValidateArguments()
+        {
+            _ = Assert.Throws<ArgumentNullException>(() => InjectableDbContextOptionsBuilderExtensions.WithLambdaInjection(null!, Array.Empty<Type>()));
+            _ = Assert.Throws<ArgumentNullException>(() => InjectableDbContextOptionsBuilderExtensions.WithLambdaInjection(new DbContextOptionsBuilder(), null!));
+        }
+
+        [Fact]
         public void ShouldInject()
         {
             var services = new ServiceCollection();


### PR DESCRIPTION
This enables *global* Lambda injection for EF Core:

```csharp
    services.AddDbContext<MyContext>(options =>
         options.UseSqlOrTheLike("...").WithLambdaInjection());
```

You're welcome.