### PR TITLE
InjectLambda works with private method in base class

### DIFF
--- a/src/NeinLinq/InjectLambdaSignature.cs
+++ b/src/NeinLinq/InjectLambdaSignature.cs
@@ -152,8 +152,8 @@ internal sealed class InjectLambdaSignature
 
             result = candidate;
         }
-        return result is not null || target.BaseType is not { } baseTarget
-            ? result
-            : FindMatch(baseTarget, method, genericArguments, parameterTypes, injectedType);
+        return result is null && target.BaseType is { } baseTarget
+            ? FindMatch(baseTarget, method, genericArguments, parameterTypes, injectedType)
+            : result;
     }
 }

--- a/src/NeinLinq/InjectLambdaSignature.cs
+++ b/src/NeinLinq/InjectLambdaSignature.cs
@@ -152,7 +152,8 @@ internal sealed class InjectLambdaSignature
 
             result = candidate;
         }
-
-        return result;
+        return result is not null || target.BaseType is not { } baseTarget
+            ? result
+            : FindMatch(baseTarget, method, genericArguments, parameterTypes, injectedType);
     }
 }

--- a/test/NeinLinq.Tests/InjectLambdaQueryTest.Inheritance.cs
+++ b/test/NeinLinq.Tests/InjectLambdaQueryTest.Inheritance.cs
@@ -197,6 +197,15 @@ public class InjectLambdaQueryTest_Inheritance
     }
 
     [Fact]
+    public void Query_WithPrivateBase_Injects()
+    {
+        FunctionsBase functions = new Functions(2);
+        var query = functions.CallVelocityWithPrivateBase(CreateQuery()).ToInjectable();
+        var result = query.ToList();
+        Assert.Equal(new[] { 200.0, .0, .12 }, result);
+    }
+
+    [Fact]
     public void Query_WithAbstractSiblingViaDerived_Injects()
     {
         var functions = new Functions(2);
@@ -350,6 +359,12 @@ public class InjectLambdaQueryTest_Inheritance
         [InjectLambda]
         public double VelocityWithAbstractSibling(Model value)
             => throw new NotSupportedException($"Unable to process {value.Name}.");
+        public IQueryable<double> CallVelocityWithPrivateBase(IQueryable<Model> query) =>
+            query.Select(m => VelocityWithPrivateBase(m));
+
+        [InjectLambda]
+        private double VelocityWithPrivateBase(Model value) =>
+            throw new NotSupportedException($"Unable to process {value.Name}.");
 
         public abstract Expression<Func<Model, double>> VelocityWithAbstractSibling();
 
@@ -421,6 +436,8 @@ public class InjectLambdaQueryTest_Inheritance
 
         public override Expression<Func<Model, double>> VelocityWithAbstractSibling()
             => v => Math.Round(v.Distance / v.Time, digits);
+        public Expression<Func<Model, double>> VelocityWithPrivateBase() =>
+            v => Math.Round(v.Distance / v.Time, digits);
 
         public override Expression<Func<Model, double>> VelocityWithVirtualSibling()
             => v => Math.Round(v.Distance / v.Time, digits);


### PR DESCRIPTION
It was not possible to have a base class with a public method, that calls a private annotated method:
```c#
public abstract class Base
{
   public IQueryable<Person> PublicMethod(IQueryable<Person> list) => list.Select(p => PrivateMethod(p));

   [InjectLambda]
   private string PrivateMethod(Person person) => throw new NotSupportedException($"Unable to process {value.Name}.");

   protected abstract Expression<Func<Person, string>> PrivateMethod();
}
public class Sub : Base
{
   public override Expression<Func<Person, string>> PrivateMethod() => v => Math.Round(v.Distance / v.Time, digits);
}
```
The reason was that the reflection method `target.GetMethods(Everything)` is not able to find private methods of the base types of `target`.
So I added a recursion which searchs in the base type if no result was found on the subtype.