### PR TITLE
Add `DebugString` for query providers providing useful strings

### DIFF
--- a/src/NeinLinq/RewriteQueryable.cs
+++ b/src/NeinLinq/RewriteQueryable.cs
@@ -71,6 +71,12 @@ public class RewriteQueryable<T> : RewriteQueryable, IOrderedQueryable<T>
     {
     }
 
+    /// <summary>
+    /// Gets a debug representation of the underlying query.
+    /// </summary>
+    public string? DebugString
+        => Provider.RewriteQuery<T>(Expression).ToString();
+
     /// <inheritdoc />
     public new IEnumerator<T> GetEnumerator()
         => Provider.RewriteQuery<T>(Expression)

--- a/test/NeinLinq.EntityFramework.Tests/EntityFrameworkRealTest.cs
+++ b/test/NeinLinq.EntityFramework.Tests/EntityFrameworkRealTest.cs
@@ -8,6 +8,17 @@ namespace NeinLinq.Tests;
 public class EntityFrameworkRealTest
 {
     [Fact]
+    public void DebugString_ShowsSql()
+    {
+        using var context = CreateContext();
+        var query = context.Models.ToDbInjectable();
+
+        var actual = ((RewriteQueryable<Model>)query).DebugString;
+
+        Assert.Matches("SELECT", actual);
+    }
+
+    [Fact]
     public async Task AsNoTracking_MarksQuery()
     {
         using var context = CreateContext();


### PR DESCRIPTION
Redirection for inner queries `ToString()` method. Useful for EF6 at least:

![image](https://github.com/axelheer/nein-linq/assets/3988385/9038d002-8d9c-4ec4-ae03-4d74df7f3150)

Fixes #41