### PR TITLE
Allow properties with setters to be injected

### DIFF
--- a/src/NeinLinq/InjectableQueryRewriter.cs
+++ b/src/NeinLinq/InjectableQueryRewriter.cs
@@ -38,7 +38,7 @@ public class InjectableQueryRewriter : ExpressionVisitor
 
         var property = node.Member as PropertyInfo;
 
-        if (property?.GetGetMethod(true) is not null && property.GetSetMethod(true) is null)
+        if (property?.GetGetMethod(true) is not null)
         {
             // cache "meta-data" for performance reasons
             var data = Cache.GetOrAdd(property, _ => InjectLambdaMetadata.Create(property));
@@ -95,6 +95,9 @@ public class InjectableQueryRewriter : ExpressionVisitor
             throw new InvalidOperationException($"Member {member.Name} has no declaring type.");
 
         // inject only configured or green-listed targets
-        return data.Config || greenlist.Any(member.DeclaringType.IsAssignableFrom);
+        var shouldInject =  data.Config || greenlist.Any(member.DeclaringType.IsAssignableFrom);
+
+        // only check if there's a lambda expression if we should inject, this avoids evaluating the LambdaFactory
+        return shouldInject && data.HasLambdaFactory;
     }
 }

--- a/test/NeinLinq.Tests/InjectLambdaQueryTest.Property.cs
+++ b/test/NeinLinq.Tests/InjectLambdaQueryTest.Property.cs
@@ -194,6 +194,29 @@ public class InjectLambdaQueryTest_Property
         Assert.Equal([200.0, .0, .125], result);
     }
 
+    [Fact]
+    public void Query_WithSetter_Injects()
+    {
+        var query = CreateQuery().ToInjectable().Select(m => m.VelocityWithSetter);
+
+        var result = query.ToList();
+
+        Assert.Equal([200.0, .0, .125], result);
+    }
+
+    [Fact]
+    public void Query_WithSetter_InjectsWhenSetting()
+    {
+        var query = CreateQuery().ToInjectable().Select(m => new Model()
+        {
+            VelocityWithSetter = m.VelocityWithSetter
+        });
+
+        var result = query.ToList().Select(m => m.VelocityWithSetter);
+
+        Assert.Equal([200.0, .0, .125], result);
+    }
+
     private static IQueryable<Model> CreateQuery()
     {
         var data = new[]
@@ -309,6 +332,12 @@ public class InjectLambdaQueryTest_Property
 
         private static CachedExpression<Func<Model, double>> VelocityWithCachedExpressionExpr
             => new(v => v.Distance / v.Time);
+
+        [InjectLambda]
+        public double VelocityWithSetter { get; set; }
+
+        public static Expression<Func<Model, double>> VelocityWithSetterExpr
+            => v => v.Distance / v.Time;
     }
 
     private static class ModelExtensions


### PR DESCRIPTION
closes #59 

Example:
```C#
[InjectLambda]
public double VelocityWithSetter { get; set; }

public static Expression<Func<Model, double>> VelocityWithSetterExpr
    => v => v.Distance / v.Time;
```

if there's a setter then there must be an `[InjectLambda]` attribute, otherwise the property will be ignored.

something unrelated I noticed while writing tests:
https://github.com/axelheer/nein-linq/blob/3fef99f130132b6d265557bd957751e427ec6629/test/NeinLinq.Tests/InjectLambdaQueryTest.Property.cs#L18-L25
this test does not call `.ToInjectable()` on the query, so I'm not sure the test would ever fail.